### PR TITLE
Add ER-API for exchange rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Codex
+
+This repository contains a simple Node.js command line app to convert an amount in USD to Indian Rupees (INR) and British Pounds (GBP).
+
+## How to run
+
+Ensure you have Node.js installed. From this directory, run the script and follow the prompt:
+
+```bash
+./currency.js
+```
+
+The program will ask for an amount in USD and fetch the latest exchange rates from [open.er-api.com](https://open.er-api.com/). It then prints the equivalent amounts in INR and GBP.

--- a/currency.js
+++ b/currency.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+const readline = require('node:readline');
+
+async function convert(amount) {
+  const url = 'https://open.er-api.com/v6/latest/USD';
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`API responded with ${res.status}`);
+  }
+  const data = await res.json();
+  return {
+    INR: data.rates.INR,
+    GBP: data.rates.GBP
+  };
+}
+
+async function run() {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });
+
+  rl.question('Enter amount in USD: ', async (answer) => {
+    const amount = parseFloat(answer);
+    if (isNaN(amount)) {
+      console.log('Invalid number.');
+      rl.close();
+      return;
+    }
+
+    try {
+      const rates = await convert(amount);
+      console.log(`You entered: $${amount}`);
+      console.log(`Converted to INR: \u20B9${(amount * rates.INR).toFixed(2)}`);
+      console.log(`Converted to GBP: \u00A3${(amount * rates.GBP).toFixed(2)}`);
+    } catch (err) {
+      console.error('Could not retrieve exchange rates.\n', err.message);
+    } finally {
+      rl.close();
+    }
+  });
+}
+
+run();


### PR DESCRIPTION
## Summary
- switch to the open.er-api.com service in the currency converter
- update README to mention the new API

## Testing
- `node currency.js <<'EOF'
100
EOF` *(fails: fetch failed)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685eb895f8708330ac79a79af1daf217