### PR TITLE
Add vanilla JavaScript todo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ Ensure you have Node.js installed. From this directory, run the script and follo
 ```
 
 The program will ask for an amount in USD and fetch the latest exchange rates from [open.er-api.com](https://open.er-api.com/). It then prints the equivalent amounts in INR and GBP.
+
+## Simple Todo App
+
+A minimal todo list lives in [`todo.html`](./todo.html) and [`todo.js`](./todo.js). Open the HTML file in any modern browser to manage tasks without installing dependencies. The interface lets you add new todos, mark them complete, delete individual items, and clear all completed tasks. Todos are stored in the browser's `localStorage` so they persist between sessions.

--- a/todo.html
+++ b/todo.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Simple Todo App</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    body {
+      margin: 0;
+      display: flex;
+      min-height: 100vh;
+      background: #f5f5f5;
+      color: #222;
+      align-items: center;
+      justify-content: center;
+    }
+
+    main {
+      width: min(520px, 90vw);
+      background: #ffffff;
+      border-radius: 16px;
+      box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+      padding: 32px 28px;
+      box-sizing: border-box;
+    }
+
+    h1 {
+      margin: 0 0 24px;
+      font-size: 2rem;
+      text-align: center;
+      letter-spacing: 0.03em;
+    }
+
+    form {
+      display: flex;
+      gap: 12px;
+      margin-bottom: 24px;
+    }
+
+    form input[type="text"] {
+      flex: 1;
+      padding: 12px 14px;
+      border-radius: 8px;
+      border: 1px solid #ddd;
+      font-size: 1rem;
+      box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.04);
+    }
+
+    form input[type="text"]:focus {
+      border-color: #5c6ac4;
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(92, 106, 196, 0.2);
+    }
+
+    form button {
+      padding: 12px 20px;
+      border-radius: 8px;
+      border: none;
+      background: #5c6ac4;
+      color: #fff;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.2s ease;
+    }
+
+    form button:hover,
+    form button:focus {
+      background: #4b57a8;
+    }
+
+    ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      gap: 12px;
+    }
+
+    li {
+      background: #f7f8ff;
+      border-radius: 10px;
+      padding: 12px 14px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      border: 1px solid #e0e3ff;
+    }
+
+    li.completed .todo-text {
+      text-decoration: line-through;
+      color: #777;
+    }
+
+    .todo-main {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex: 1;
+    }
+
+    .todo-text {
+      word-break: break-word;
+    }
+
+    .actions {
+      display: flex;
+      gap: 8px;
+    }
+
+    button[data-action] {
+      border: none;
+      background: transparent;
+      color: #5c6ac4;
+      cursor: pointer;
+      font-weight: 600;
+      padding: 6px 10px;
+      border-radius: 6px;
+      transition: background 0.2s ease;
+    }
+
+    button[data-action]:hover,
+    button[data-action]:focus {
+      background: rgba(92, 106, 196, 0.1);
+    }
+
+    .empty-state {
+      text-align: center;
+      padding: 24px 12px;
+      color: #777;
+    }
+
+    #clear-completed {
+      width: 100%;
+      margin-top: 24px;
+      padding: 12px;
+      border: 1px solid #ddd;
+      border-radius: 10px;
+      background: #fff;
+      cursor: pointer;
+      font-weight: 600;
+      color: #444;
+      transition: background 0.2s ease;
+    }
+
+    #clear-completed:hover,
+    #clear-completed:focus {
+      background: #f0f0f0;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Todo List</h1>
+    <form id="todo-form" autocomplete="off">
+      <input id="todo-input" type="text" name="todo" placeholder="What needs to be done?" required />
+      <button type="submit">Add</button>
+    </form>
+    <ul id="todo-list" aria-live="polite"></ul>
+    <p id="empty-state" class="empty-state" hidden>No tasks yet — add your first todo above!</p>
+    <button id="clear-completed" type="button">Clear completed tasks</button>
+  </main>
+  <script src="todo.js"></script>
+</body>
+</html>

--- a/todo.js
+++ b/todo.js
@@ -1,0 +1,157 @@
+(function () {
+  const STORAGE_KEY = 'simple-todo-items';
+
+  const form = document.getElementById('todo-form');
+  const input = document.getElementById('todo-input');
+  const list = document.getElementById('todo-list');
+  const emptyState = document.getElementById('empty-state');
+  const clearCompletedButton = document.getElementById('clear-completed');
+
+  let todos = loadTodos();
+  render();
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const text = input.value.trim();
+    if (!text) {
+      return;
+    }
+
+    todos.push(createTodo(text));
+    input.value = '';
+    persist();
+    render();
+  });
+
+  list.addEventListener('click', (event) => {
+    const target = event.target;
+    const item = target.closest('li');
+    if (!item) return;
+    const todoId = item.dataset.id;
+
+    if (target.matches('input[type="checkbox"]')) {
+      toggleTodo(todoId, target.checked);
+    }
+
+    if (target.matches('button[data-action="delete"]')) {
+      deleteTodo(todoId);
+    }
+  });
+
+  clearCompletedButton.addEventListener('click', () => {
+    const beforeLength = todos.length;
+    todos = todos.filter((todo) => !todo.completed);
+    if (todos.length !== beforeLength) {
+      persist();
+      render();
+    }
+  });
+
+  function createTodo(text) {
+    return {
+      id: crypto.randomUUID ? crypto.randomUUID() : String(Date.now() + Math.random()),
+      text,
+      completed: false,
+      createdAt: Date.now(),
+    };
+  }
+
+  function toggleTodo(id, completed) {
+    const todo = todos.find((item) => item.id === id);
+    if (todo) {
+      todo.completed = completed;
+      persist();
+      render();
+    }
+  }
+
+  function deleteTodo(id) {
+    const nextTodos = todos.filter((item) => item.id !== id);
+    if (nextTodos.length !== todos.length) {
+      todos = nextTodos;
+      persist();
+      render();
+    }
+  }
+
+  function render() {
+    list.innerHTML = '';
+    if (todos.length === 0) {
+      emptyState.hidden = false;
+      return;
+    }
+
+    emptyState.hidden = true;
+    const sorted = [...todos].sort((a, b) => a.createdAt - b.createdAt);
+    const fragment = document.createDocumentFragment();
+
+    for (const todo of sorted) {
+      fragment.appendChild(createTodoElement(todo));
+    }
+
+    list.appendChild(fragment);
+  }
+
+  function createTodoElement(todo) {
+    const item = document.createElement('li');
+    item.dataset.id = todo.id;
+    if (todo.completed) {
+      item.classList.add('completed');
+    }
+
+    const main = document.createElement('div');
+    main.className = 'todo-main';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = todo.completed;
+    checkbox.setAttribute('aria-label', `Mark "${todo.text}" as ${todo.completed ? 'incomplete' : 'completed'}`);
+
+    const text = document.createElement('span');
+    text.className = 'todo-text';
+    text.textContent = todo.text;
+
+    main.append(checkbox, text);
+
+    const actions = document.createElement('div');
+    actions.className = 'actions';
+
+    const deleteButton = document.createElement('button');
+    deleteButton.type = 'button';
+    deleteButton.dataset.action = 'delete';
+    deleteButton.textContent = 'Delete';
+
+    actions.appendChild(deleteButton);
+
+    item.append(main, actions);
+    return item;
+  }
+
+  function loadTodos() {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (!stored) return [];
+      const parsed = JSON.parse(stored);
+      if (!Array.isArray(parsed)) return [];
+      return parsed
+        .filter((item) => typeof item === 'object' && item !== null && 'id' in item && 'text' in item)
+        .map((item) => ({
+          id: String(item.id),
+          text: String(item.text),
+          completed: Boolean(item.completed),
+          createdAt: typeof item.createdAt === 'number' ? item.createdAt : Date.now(),
+        }));
+    } catch (error) {
+      console.warn('Failed to load todos from storage', error);
+      return [];
+    }
+  }
+
+  function persist() {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(todos));
+    } catch (error) {
+      console.warn('Failed to save todos to storage', error);
+    }
+  }
+})();


### PR DESCRIPTION
## Summary
- add a standalone todo.html page backed by plain JavaScript and browser storage
- implement todo.js to handle creating, toggling, deleting, and clearing todos with localStorage persistence
- document the new todo app alongside the existing currency converter in the README

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d336c305bc8330806865cf6c596e0c